### PR TITLE
Tag bundle - precompute optimization

### DIFF
--- a/cfg/tags_36h11.yaml
+++ b/cfg/tags_36h11.yaml
@@ -23,3 +23,20 @@
             ids: [9, 14]            # tag ID
             frames: [base, object]  # optional frame name
             sizes: [0.162, 0.162]   # optional tag-specific edge size
+
+        # optional list of tag bundles
+        tag_bundles:
+            bundle_names: ['bundle1', 'bundle2']
+            bundle1:
+                ids: [0, 1] # tag IDs in bundle
+                "0":
+                    size: 0.1
+                    transform: [-0.25, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] # [x, y, z, qw, qx, qy, qz]
+                "1":
+                    size: 0.1
+                    transform: [0.25, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] # [x, y, z, qw, qx, qy, qz]
+            bundle2:
+                ids: [0] # tag IDs in bundle
+                "0":
+                    size: 0.1
+                    transform: [-0.25, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0] # [x, y, z, qw, qx, qy, qz]

--- a/cfg/tags_36h11.yaml
+++ b/cfg/tags_36h11.yaml
@@ -24,18 +24,19 @@
             frames: [base, object]  # optional frame name
             sizes: [0.162, 0.162]   # optional tag-specific edge size
 
+        # optional list of tag bundles
         tag_bundles:
             bundle_names: ['bundle1', 'bundle2']
             bundle1:
                 ids: [0, 1] # tag IDs in bundle
                 0:
                     size: 0.1
-                    transform: [-0.25, 0.0, 0.0, 0.0, 0.0, 0.0] 
+                    transform: [-0.25, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] # [x, y, z, qw, qx, qy, qz]
                 1:
                     size: 0.1
-                    transform: [0.25, 0.0, 0.0, 0.0, 0.0, 0.0] 
+                    transform: [0.25, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0] # [x, y, z, qw, qx, qy, qz]
             bundle2:
                 ids: [0] # tag IDs in bundle
                 0:
                     size: 0.1
-                    transform: [0.25, 0.0, 0.0, 0.0, 0.0, 0.0] 
+                    transform: [-0.25, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0] # [x, y, z, qw, qx, qy, qz]

--- a/cfg/tags_36h11.yaml
+++ b/cfg/tags_36h11.yaml
@@ -23,3 +23,19 @@
             ids: [9, 14]            # tag ID
             frames: [base, object]  # optional frame name
             sizes: [0.162, 0.162]   # optional tag-specific edge size
+
+        tag_bundles:
+            bundle_names: ['bundle1', 'bundle2']
+            bundle1:
+                ids: [0, 1] # tag IDs in bundle
+                0:
+                    size: 0.1
+                    transform: [-0.25, 0.0, 0.0, 0.0, 0.0, 0.0] 
+                1:
+                    size: 0.1
+                    transform: [0.25, 0.0, 0.0, 0.0, 0.0, 0.0] 
+            bundle2:
+                ids: [0] # tag IDs in bundle
+                0:
+                    size: 0.1
+                    transform: [0.25, 0.0, 0.0, 0.0, 0.0, 0.0] 

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -7,14 +7,14 @@
 #else
 #include <cv_bridge/cv_bridge.h>
 #endif
+#include <Eigen/Geometry>
 #include <image_transport/camera_subscriber.hpp>
+#include <opencv2/calib3d.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <tf2_ros/transform_broadcaster.hpp>
-#include <Eigen/Geometry>
-#include <opencv2/calib3d.hpp>
 
 // apriltag
 #include "tag_functions.hpp"
@@ -192,7 +192,7 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
             const std::string prefix = "tag_bundles." + bundle_name + "." + std::to_string(id);
             bundle->id_to_size[id] = declare_parameter(prefix + ".size", 1.0, descr("bundle size", true));
             bundle->id_to_tf[id] = declare_parameter(prefix + ".transform", std::vector<double>{}, descr("bundle transform", true));
-            if (bundle->id_to_tf[id].size() != 7) {
+            if(bundle->id_to_tf[id].size() != 7) {
                 throw std::runtime_error("Invalid transform size for tag id " + std::to_string(id));
             }
         }
@@ -223,7 +223,7 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
         throw std::runtime_error("Unsupported tag family: " + tag_family);
     }
 
-    for (TagBundlePtr& bundle : all_tag_bundles) {
+    for(TagBundlePtr& bundle : all_tag_bundles) {
         // pre-compute bundle-frame tag points
         for(const int64_t& id : bundle->ids) {
             double s = bundle->id_to_size[id] / 2;

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -86,6 +86,8 @@ private:
     double tag_edge_size;
     std::atomic<int> max_hamming;
     std::atomic<bool> profile;
+    std::vector<TagBundle> all_tag_bundles;
+    std::set<int64_t> tags_in_bundles;
     std::unordered_map<int, std::string> tag_frames;
     std::unordered_map<int, double> tag_sizes;
 
@@ -173,14 +175,14 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
     declare_parameter("max_hamming", 0, descr("reject detections with more corrected bits than allowed"));
     declare_parameter("profile", false, descr("print profiling information to stdout"));
 
-    for(auto& bundle_name : bundle_names) {
-
+    for(const std::string& bundle_name : bundle_names) {
         TagBundle bundle;
 
         bundle.frame_id = bundle_name;
         bundle.ids = declare_parameter("tag_bundles." + bundle_name + ".ids", std::vector<int64_t>{}, descr("bundle ids", true));
 
-        for(auto& id : bundle.ids) {
+        for(const int64_t& id : bundle.ids) {
+            tags_in_bundles.insert(id);
             const std::string prefix = "tag_bundles." + bundle_name + "." + std::to_string(id);
             bundle.id_to_size[id] = declare_parameter(prefix + ".size", 1.0, descr("bundle size", true));
             bundle.id_to_tf[id] = declare_parameter(prefix + ".transform", std::vector<double>{}, descr("bundle transform", true));
@@ -264,11 +266,10 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
         if(det->hamming > max_hamming) { continue; }
 
         // For all detections, extract relevant ones to bundle_detections
-        for(auto& bundle : all_tag_bundles) {
+        for(const TagBundle& bundle : all_tag_bundles) {
             bool id_in_bundle = (std::find(bundle.ids.begin(), bundle.ids.end(), det->id) != bundle.ids.end());
             if(id_in_bundle) {
                 bundle_detections[bundle.frame_id].push_back(det);
-                // RCLCPP_INFO(get_logger(), "tag of id %i found", det->id);
             }
         }
 
@@ -291,6 +292,8 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
         if(estimate_pose != nullptr && calibrated) {
             geometry_msgs::msg::TransformStamped tf;
             tf.header = msg_img->header;
+            // if tag id is already in a bundle and tag is not defined in parameter file, don't estimate and publish transform
+            if((tags_in_bundles.find(det->id) != tags_in_bundles.end()) && (tag_frames.count(det->id) == 0)) { continue; }
             // set child frame name by generic tag name or configured tag name
             tf.child_frame_id = tag_frames.count(det->id) ? tag_frames.at(det->id) : std::string(det->family->name) + ":" + std::to_string(det->id);
             const double size = tag_sizes.count(det->id) ? tag_sizes.at(det->id) : tag_edge_size;
@@ -299,20 +302,21 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
         }
     }
 
-    for(auto& bundle : all_tag_bundles) {
-        geometry_msgs::msg::TransformStamped bundle_transform_stamped;
-        if(bundle_detections.find(bundle.frame_id) != bundle_detections.end()) {
-            bundle_transform_stamped.header = msg_img->header;
-            bundle_transform_stamped.child_frame_id = bundle.frame_id;
-            bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle.frame_id], intrinsics, bundle.id_to_size, bundle.id_to_tf);
-            tf_broadcaster.sendTransform(bundle_transform_stamped);
-        }
-    }
 
     pub_detections->publish(msg_detections);
 
-    if(estimate_pose != nullptr)
+    if(estimate_pose != nullptr) {
+        for(auto& bundle : all_tag_bundles) {
+            geometry_msgs::msg::TransformStamped bundle_transform_stamped;
+            if(bundle_detections.find(bundle.frame_id) != bundle_detections.end()) {
+                bundle_transform_stamped.header = msg_img->header;
+                bundle_transform_stamped.child_frame_id = bundle.frame_id;
+                bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle.frame_id], intrinsics, bundle.id_to_size, bundle.id_to_tf);
+                tf_broadcaster.sendTransform(bundle_transform_stamped);
+            }
+        }
         tf_broadcaster.sendTransform(tfs);
+    }
 
     apriltag_detections_destroy(detections);
 }

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -269,7 +269,7 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
         if(det->hamming > max_hamming) { continue; }
 
         // For all detections, extract relevant ones to bundle_detections
-        if (tag_id_to_bundles.count(det->id)) {
+        if(tag_id_to_bundles.count(det->id)) {
             for(const TagBundlePtr& bundle : tag_id_to_bundles[det->id]) {
                 bundle_detections[bundle->frame_id].push_back(det);
             }

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -61,6 +61,14 @@ const static std::unordered_map<std::string, rmw_qos_profile_t> qos_profiles{
     {"system_default", rmw_qos_profile_system_default},
 };
 
+struct TagBundle
+{
+    std::vector<int64_t> ids;
+    std::unordered_map<int, double> id_to_size;
+    std::unordered_map<int, std::vector<double>> id_to_tf;
+    std::string frame_id;
+};
+
 class AprilTagNode : public rclcpp::Node {
 public:
     AprilTagNode(const rclcpp::NodeOptions& options);
@@ -165,6 +173,21 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
     declare_parameter("max_hamming", 0, descr("reject detections with more corrected bits than allowed"));
     declare_parameter("profile", false, descr("print profiling information to stdout"));
 
+    for(auto& bundle_name : bundle_names) {
+
+        TagBundle bundle;
+
+        bundle.frame_id = bundle_name;
+        bundle.ids = declare_parameter("tag_bundles." + bundle_name + ".ids", std::vector<int64_t>{}, descr("bundle ids", true));
+
+        for(auto& id : bundle.ids) {
+            const std::string prefix = "tag_bundles." + bundle_name + "." + std::to_string(id);
+            bundle.id_to_size[id] = declare_parameter(prefix + ".size", 1.0, descr("bundle size", true));
+            bundle.id_to_tf[id] = declare_parameter(prefix + ".transform", std::vector<double>{}, descr("bundle transform", true));
+        }
+        all_tag_bundles.push_back(bundle);
+    }
+
     if(!frames.empty()) {
         if(ids.size() != frames.size()) {
             throw std::runtime_error("Number of tag ids (" + std::to_string(ids.size()) + ") and frames (" + std::to_string(frames.size()) + ") mismatch!");
@@ -237,11 +260,20 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
                      i, det->family->nbits, det->family->h, det->id,
                      det->hamming, det->decision_margin);
 
-        // ignore untracked tags
-        if(!tag_frames.empty() && !tag_frames.count(det->id)) { continue; }
-
         // reject detections with more corrected bits than allowed
         if(det->hamming > max_hamming) { continue; }
+
+        // For all detections, extract relevant ones to bundle_detections
+        for(auto& bundle : all_tag_bundles) {
+            bool id_in_bundle = (std::find(bundle.ids.begin(), bundle.ids.end(), det->id) != bundle.ids.end());
+            if(id_in_bundle) {
+                bundle_detections[bundle.frame_id].push_back(det);
+                // RCLCPP_INFO(get_logger(), "tag of id %i found", det->id);
+            }
+        }
+
+        // ignore untracked tags
+        if(!tag_frames.empty() && !tag_frames.count(det->id)) { continue; }
 
         // detection
         apriltag_msgs::msg::AprilTagDetection msg_detection;
@@ -264,6 +296,16 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
             const double size = tag_sizes.count(det->id) ? tag_sizes.at(det->id) : tag_edge_size;
             tf.transform = estimate_pose(det, intrinsics, size);
             tfs.push_back(tf);
+        }
+    }
+
+    for(auto& bundle : all_tag_bundles) {
+        geometry_msgs::msg::TransformStamped bundle_transform_stamped;
+        if(bundle_detections.find(bundle.frame_id) != bundle_detections.end()) {
+            bundle_transform_stamped.header = msg_img->header;
+            bundle_transform_stamped.child_frame_id = bundle.frame_id;
+            bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle.frame_id], intrinsics, bundle.id_to_size, bundle.id_to_tf);
+            tf_broadcaster.sendTransform(bundle_transform_stamped);
         }
     }
 

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -13,6 +13,8 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <tf2_ros/transform_broadcaster.hpp>
+#include <Eigen/Geometry>
+#include <opencv2/calib3d.hpp>
 
 // apriltag
 #include "tag_functions.hpp"
@@ -66,6 +68,7 @@ struct TagBundle
     std::set<int64_t> ids;
     std::unordered_map<int, double> id_to_size;
     std::unordered_map<int, std::vector<double>> id_to_tf;
+    std::unordered_map<int, std::array<cv::Point3d, 4>> id_to_corners;
     std::string frame_id;
 };
 
@@ -189,6 +192,9 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
             const std::string prefix = "tag_bundles." + bundle_name + "." + std::to_string(id);
             bundle->id_to_size[id] = declare_parameter(prefix + ".size", 1.0, descr("bundle size", true));
             bundle->id_to_tf[id] = declare_parameter(prefix + ".transform", std::vector<double>{}, descr("bundle transform", true));
+            if (bundle->id_to_tf[id].size() != 7) {
+                throw std::runtime_error("Invalid transform size for tag id " + std::to_string(id));
+            }
         }
         all_tag_bundles.push_back(bundle);
     }
@@ -215,6 +221,25 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
     }
     else {
         throw std::runtime_error("Unsupported tag family: " + tag_family);
+    }
+
+    for (TagBundlePtr& bundle : all_tag_bundles) {
+        // pre-compute bundle-frame tag points
+        for(const int64_t& id : bundle->ids) {
+            double s = bundle->id_to_size[id] / 2;
+            const std::array<Eigen::Vector3d, 4> corners = {
+                Eigen::Vector3d(-s, -s, 0),
+                Eigen::Vector3d(+s, -s, 0),
+                Eigen::Vector3d(+s, +s, 0),
+                Eigen::Vector3d(-s, +s, 0)};
+            const std::vector<double>& tf = bundle->id_to_tf[id];
+            Eigen::Affine3d transform = Eigen::Translation3d(tf[0], tf[1], tf[2]) * Eigen::Quaternion<double>(tf[3], tf[4], tf[5], tf[6]);
+
+            for(size_t i = 0; i < corners.size(); i++) {
+                Eigen::Vector3d transformed_point = transform * corners[i];
+                bundle->id_to_corners[id][i] = cv::Point3d(transformed_point.x(), transformed_point.y(), transformed_point.z());
+            }
+        }
     }
 }
 
@@ -308,12 +333,13 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
     pub_detections->publish(msg_detections);
 
     if(estimate_pose != nullptr) {
-        for(auto& bundle : all_tag_bundles) {
+        // note: this could also use a map of tag id -> TagBundleVec
+        for(const TagBundlePtr& bundle : all_tag_bundles) {
             geometry_msgs::msg::TransformStamped bundle_transform_stamped;
             if(bundle_detections.count(bundle->frame_id)) {
                 bundle_transform_stamped.header = msg_img->header;
                 bundle_transform_stamped.child_frame_id = bundle->frame_id;
-                bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle->frame_id], intrinsics, bundle->id_to_size, bundle->id_to_tf);
+                bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle->frame_id], intrinsics, bundle->id_to_corners);
                 tf_broadcaster.sendTransform(bundle_transform_stamped);
             }
         }

--- a/src/AprilTagNode.cpp
+++ b/src/AprilTagNode.cpp
@@ -63,7 +63,7 @@ const static std::unordered_map<std::string, rmw_qos_profile_t> qos_profiles{
 
 struct TagBundle
 {
-    std::vector<int64_t> ids;
+    std::set<int64_t> ids;
     std::unordered_map<int, double> id_to_size;
     std::unordered_map<int, std::vector<double>> id_to_tf;
     std::string frame_id;
@@ -74,6 +74,9 @@ public:
     AprilTagNode(const rclcpp::NodeOptions& options);
 
     ~AprilTagNode() override;
+
+    typedef std::shared_ptr<TagBundle> TagBundlePtr;
+    typedef std::vector<TagBundlePtr> TagBundleVec;
 
 private:
     const OnSetParametersCallbackHandle::SharedPtr cb_parameter;
@@ -86,8 +89,8 @@ private:
     double tag_edge_size;
     std::atomic<int> max_hamming;
     std::atomic<bool> profile;
-    std::vector<TagBundle> all_tag_bundles;
-    std::set<int64_t> tags_in_bundles;
+    TagBundleVec all_tag_bundles;
+    std::unordered_map<int64_t, TagBundleVec> tag_id_to_bundles;
     std::unordered_map<int, std::string> tag_frames;
     std::unordered_map<int, double> tag_sizes;
 
@@ -176,16 +179,16 @@ AprilTagNode::AprilTagNode(const rclcpp::NodeOptions& options)
     declare_parameter("profile", false, descr("print profiling information to stdout"));
 
     for(const std::string& bundle_name : bundle_names) {
-        TagBundle bundle;
+        TagBundlePtr bundle = std::make_shared<TagBundle>();
 
-        bundle.frame_id = bundle_name;
-        bundle.ids = declare_parameter("tag_bundles." + bundle_name + ".ids", std::vector<int64_t>{}, descr("bundle ids", true));
-
-        for(const int64_t& id : bundle.ids) {
-            tags_in_bundles.insert(id);
+        bundle->frame_id = bundle_name;
+        std::vector<int64_t> bundle_ids_vector = declare_parameter("tag_bundles." + bundle_name + ".ids", std::vector<int64_t>{}, descr("bundle ids", true));
+        bundle->ids = std::set<int64_t>(bundle_ids_vector.begin(), bundle_ids_vector.end());
+        for(const int64_t& id : bundle->ids) {
+            tag_id_to_bundles[id].push_back(bundle);
             const std::string prefix = "tag_bundles." + bundle_name + "." + std::to_string(id);
-            bundle.id_to_size[id] = declare_parameter(prefix + ".size", 1.0, descr("bundle size", true));
-            bundle.id_to_tf[id] = declare_parameter(prefix + ".transform", std::vector<double>{}, descr("bundle transform", true));
+            bundle->id_to_size[id] = declare_parameter(prefix + ".size", 1.0, descr("bundle size", true));
+            bundle->id_to_tf[id] = declare_parameter(prefix + ".transform", std::vector<double>{}, descr("bundle transform", true));
         }
         all_tag_bundles.push_back(bundle);
     }
@@ -266,10 +269,9 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
         if(det->hamming > max_hamming) { continue; }
 
         // For all detections, extract relevant ones to bundle_detections
-        for(const TagBundle& bundle : all_tag_bundles) {
-            bool id_in_bundle = (std::find(bundle.ids.begin(), bundle.ids.end(), det->id) != bundle.ids.end());
-            if(id_in_bundle) {
-                bundle_detections[bundle.frame_id].push_back(det);
+        if (tag_id_to_bundles.count(det->id)) {
+            for(const TagBundlePtr& bundle : tag_id_to_bundles[det->id]) {
+                bundle_detections[bundle->frame_id].push_back(det);
             }
         }
 
@@ -293,7 +295,7 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
             geometry_msgs::msg::TransformStamped tf;
             tf.header = msg_img->header;
             // if tag id is already in a bundle and tag is not defined in parameter file, don't estimate and publish transform
-            if((tags_in_bundles.find(det->id) != tags_in_bundles.end()) && (tag_frames.count(det->id) == 0)) { continue; }
+            if((tag_id_to_bundles.find(det->id) != tag_id_to_bundles.end()) && (tag_frames.count(det->id) == 0)) { continue; }
             // set child frame name by generic tag name or configured tag name
             tf.child_frame_id = tag_frames.count(det->id) ? tag_frames.at(det->id) : std::string(det->family->name) + ":" + std::to_string(det->id);
             const double size = tag_sizes.count(det->id) ? tag_sizes.at(det->id) : tag_edge_size;
@@ -308,10 +310,10 @@ void AprilTagNode::onCamera(const sensor_msgs::msg::Image::ConstSharedPtr& msg_i
     if(estimate_pose != nullptr) {
         for(auto& bundle : all_tag_bundles) {
             geometry_msgs::msg::TransformStamped bundle_transform_stamped;
-            if(bundle_detections.find(bundle.frame_id) != bundle_detections.end()) {
+            if(bundle_detections.count(bundle->frame_id)) {
                 bundle_transform_stamped.header = msg_img->header;
-                bundle_transform_stamped.child_frame_id = bundle.frame_id;
-                bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle.frame_id], intrinsics, bundle.id_to_size, bundle.id_to_tf);
+                bundle_transform_stamped.child_frame_id = bundle->frame_id;
+                bundle_transform_stamped.transform = pnp_bundle(bundle_detections[bundle->frame_id], intrinsics, bundle->id_to_size, bundle->id_to_tf);
                 tf_broadcaster.sendTransform(bundle_transform_stamped);
             }
         }

--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -68,7 +68,7 @@ pnp_bundle(std::vector<apriltag_detection_t*> detections,
         double s = tagsizes[id] / 2;
         std::vector<double> tf_vec = transforms[detection->id];
 
-        Eigen::Quaternion<double> quat(tf_vec[3], tf_vec[4], tf_vec[5], tf_vec[6]); // qw, qx, qy, qz
+        Eigen::Quaternion<double> quat(tf_vec[3], tf_vec[4], tf_vec[5], tf_vec[6]);// qw, qx, qy, qz
 
         Eigen::Matrix3d rot_mat = quat.matrix();
         cv::Matx44d tf_mat(rot_mat(0, 0), rot_mat(0, 1), rot_mat(0, 2), tf_vec[0],

--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -68,11 +68,7 @@ pnp_bundle(std::vector<apriltag_detection_t*> detections,
         double s = tagsizes[id] / 2;
         std::vector<double> tf_vec = transforms[detection->id];
 
-        Eigen::AngleAxisd roll(tf_vec[3], Eigen::Vector3d::UnitX());
-        Eigen::AngleAxisd pitch(tf_vec[4], Eigen::Vector3d::UnitY());
-        Eigen::AngleAxisd yaw(tf_vec[5], Eigen::Vector3d::UnitZ());
-
-        Eigen::Quaternion<double> quat = roll * pitch * yaw;
+        Eigen::Quaternion<double> quat(tf_vec[3], tf_vec[4], tf_vec[5], tf_vec[6]); // qw, qx, qy, qz
 
         Eigen::Matrix3d rot_mat = quat.matrix();
         cv::Matx44d tf_mat(rot_mat(0, 0), rot_mat(0, 1), rot_mat(0, 2), tf_vec[0],

--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -25,6 +25,24 @@ homography(apriltag_detection_t* const detection, const std::array<double, 4>& i
     return tf2::toMsg<apriltag_pose_t, geometry_msgs::msg::Transform>(const_cast<const apriltag_pose_t&>(pose));
 }
 
+geometry_msgs::msg::Transform pnp_from_points(
+    const std::vector<cv::Point3d>& objectPoints,
+    const std::vector<cv::Point2d>& imagePoints,
+    const std::array<double, 4>& intr
+) {
+    cv::Matx33d cameraMatrix;
+    cameraMatrix(0, 0) = intr[0];// fx
+    cameraMatrix(1, 1) = intr[1];// fy
+    cameraMatrix(0, 2) = intr[2];// cx
+    cameraMatrix(1, 2) = intr[3];// cy
+
+    cv::Mat rvec, tvec;
+    cv::solvePnP(objectPoints, imagePoints, cameraMatrix, {}, rvec, tvec);
+
+    return tf2::toMsg<std::pair<cv::Mat_<double>, cv::Mat_<double>>, geometry_msgs::msg::Transform>(std::make_pair(tvec, rvec));
+}
+
+
 geometry_msgs::msg::Transform
 pnp(apriltag_detection_t* const detection, const std::array<double, 4>& intr, double tagsize)
 {
@@ -42,16 +60,7 @@ pnp(apriltag_detection_t* const detection, const std::array<double, 4>& intr, do
         {detection->p[3][0], detection->p[3][1]},
     };
 
-    cv::Matx33d cameraMatrix;
-    cameraMatrix(0, 0) = intr[0];// fx
-    cameraMatrix(1, 1) = intr[1];// fy
-    cameraMatrix(0, 2) = intr[2];// cx
-    cameraMatrix(1, 2) = intr[3];// cy
-
-    cv::Mat rvec, tvec;
-    cv::solvePnP(objectPoints, imagePoints, cameraMatrix, {}, rvec, tvec);
-
-    return tf2::toMsg<std::pair<cv::Mat_<double>, cv::Mat_<double>>, geometry_msgs::msg::Transform>(std::make_pair(tvec, rvec));
+    return pnp_from_points(objectPoints, imagePoints, intr);
 }
 
 geometry_msgs::msg::Transform
@@ -63,11 +72,12 @@ pnp_bundle(std::vector<apriltag_detection_t*> detections,
     std::vector<cv::Point3d> objectPoints;
     std::vector<cv::Point2d> imagePoints;
 
-    for(auto& detection : detections) {
+    for(const apriltag_detection_t* detection : detections) {
         int id = detection->id;
         double s = tagsizes[id] / 2;
         std::vector<double> tf = transforms[detection->id];
 
+        // note: The tag bundles should probably store pre-computed bundle-frame tag points rather than recalculating it every detection
         std::vector<Eigen::Vector3d> corners = {
             Eigen::Vector3d(-s, -s, 0),
             Eigen::Vector3d(+s, -s, 0),
@@ -86,18 +96,8 @@ pnp_bundle(std::vector<apriltag_detection_t*> detections,
         }
     }
 
-    cv::Matx33d cameraMatrix;
-    cameraMatrix(0, 0) = intr[0];// fx
-    cameraMatrix(1, 1) = intr[1];// fy
-    cameraMatrix(0, 2) = intr[2];// cx
-    cameraMatrix(1, 2) = intr[3];// cy
-
-    cv::Mat rvec, tvec;
-    cv::solvePnP(objectPoints, imagePoints, cameraMatrix, {}, rvec, tvec);
-
-    return tf2::toMsg<std::pair<cv::Mat_<double>, cv::Mat_<double>>, geometry_msgs::msg::Transform>(std::make_pair(tvec, rvec));
+    return pnp_from_points(objectPoints, imagePoints, intr);
 }
-
 const std::unordered_map<std::string, pose_estimation_f> pose_estimation_methods{
     {"homography", homography},
     {"pnp", pnp},

--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -28,8 +28,8 @@ homography(apriltag_detection_t* const detection, const std::array<double, 4>& i
 geometry_msgs::msg::Transform pnp_from_points(
     const std::vector<cv::Point3d>& objectPoints,
     const std::vector<cv::Point2d>& imagePoints,
-    const std::array<double, 4>& intr
-) {
+    const std::array<double, 4>& intr)
+{
     cv::Matx33d cameraMatrix;
     cameraMatrix(0, 0) = intr[0];// fx
     cameraMatrix(1, 1) = intr[1];// fy

--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -66,29 +66,14 @@ pnp(apriltag_detection_t* const detection, const std::array<double, 4>& intr, do
 geometry_msgs::msg::Transform
 pnp_bundle(std::vector<apriltag_detection_t*> detections,
            const std::array<double, 4>& intr,
-           std::unordered_map<int, double> tagsizes,
-           std::unordered_map<int, std::vector<double>> transforms)
+           const std::unordered_map<int, std::array<cv::Point3d, 4>>& id_to_corners)
 {
     std::vector<cv::Point3d> objectPoints;
     std::vector<cv::Point2d> imagePoints;
 
     for(const apriltag_detection_t* detection : detections) {
-        int id = detection->id;
-        double s = tagsizes[id] / 2;
-        std::vector<double> tf = transforms[detection->id];
-
-        // note: The tag bundles should probably store pre-computed bundle-frame tag points rather than recalculating it every detection
-        std::vector<Eigen::Vector3d> corners = {
-            Eigen::Vector3d(-s, -s, 0),
-            Eigen::Vector3d(+s, -s, 0),
-            Eigen::Vector3d(+s, +s, 0),
-            Eigen::Vector3d(-s, +s, 0)};
-
-        Eigen::Affine3d transform = Eigen::Translation3d(tf[0], tf[1], tf[2]) * Eigen::Quaternion<double>(tf[3], tf[4], tf[5], tf[6]);
-
-        for(const Eigen::Vector3d& point : corners) {
-            Eigen::Vector3d transformed_point = transform * point;
-            objectPoints.push_back(cv::Point3d(transformed_point.x(), transformed_point.y(), transformed_point.z()));
+        for(const cv::Point3d& point : id_to_corners.at(detection->id)) {
+            objectPoints.push_back(point);
         }
         // Add image points
         for(int i = 0; i < 4; i++) {

--- a/src/pose_estimation.cpp
+++ b/src/pose_estimation.cpp
@@ -54,6 +54,55 @@ pnp(apriltag_detection_t* const detection, const std::array<double, 4>& intr, do
     return tf2::toMsg<std::pair<cv::Mat_<double>, cv::Mat_<double>>, geometry_msgs::msg::Transform>(std::make_pair(tvec, rvec));
 }
 
+geometry_msgs::msg::Transform
+pnp_bundle(std::vector<apriltag_detection_t*> detections,
+           const std::array<double, 4>& intr,
+           std::unordered_map<int, double> tagsizes,
+           std::unordered_map<int, std::vector<double>> transforms)
+{
+    std::vector<cv::Point3d> objectPoints;
+    std::vector<cv::Point2d> imagePoints;
+
+    for(auto& detection : detections) {
+        int id = detection->id;
+        double s = tagsizes[id] / 2;
+        std::vector<double> tf_vec = transforms[detection->id];
+
+        Eigen::AngleAxisd roll(tf_vec[3], Eigen::Vector3d::UnitX());
+        Eigen::AngleAxisd pitch(tf_vec[4], Eigen::Vector3d::UnitY());
+        Eigen::AngleAxisd yaw(tf_vec[5], Eigen::Vector3d::UnitZ());
+
+        Eigen::Quaternion<double> quat = roll * pitch * yaw;
+
+        Eigen::Matrix3d rot_mat = quat.matrix();
+        cv::Matx44d tf_mat(rot_mat(0, 0), rot_mat(0, 1), rot_mat(0, 2), tf_vec[0],
+                           rot_mat(1, 0), rot_mat(1, 1), rot_mat(1, 2), tf_vec[1],
+                           rot_mat(2, 0), rot_mat(2, 1), rot_mat(2, 2), tf_vec[2],
+                           0, 0, 0, 1);
+
+        objectPoints.push_back(tf_mat.get_minor<3, 4>(0, 0) * cv::Vec4d(-s, -s, 0, 1));
+        objectPoints.push_back(tf_mat.get_minor<3, 4>(0, 0) * cv::Vec4d(+s, -s, 0, 1));
+        objectPoints.push_back(tf_mat.get_minor<3, 4>(0, 0) * cv::Vec4d(+s, +s, 0, 1));
+        objectPoints.push_back(tf_mat.get_minor<3, 4>(0, 0) * cv::Vec4d(-s, +s, 0, 1));
+
+        // Add image points
+        for(int i = 0; i < 4; i++) {
+            imagePoints.push_back({detection->p[i][0], detection->p[i][1]});
+        }
+    }
+
+    cv::Matx33d cameraMatrix;
+    cameraMatrix(0, 0) = intr[0];// fx
+    cameraMatrix(1, 1) = intr[1];// fy
+    cameraMatrix(0, 2) = intr[2];// cx
+    cameraMatrix(1, 2) = intr[3];// cy
+
+    cv::Mat rvec, tvec;
+    cv::solvePnP(objectPoints, imagePoints, cameraMatrix, {}, rvec, tvec);
+
+    return tf2::toMsg<std::pair<cv::Mat_<double>, cv::Mat_<double>>, geometry_msgs::msg::Transform>(std::make_pair(tvec, rvec));
+}
+
 const std::unordered_map<std::string, pose_estimation_f> pose_estimation_methods{
     {"homography", homography},
     {"pnp", pnp},

--- a/src/pose_estimation.hpp
+++ b/src/pose_estimation.hpp
@@ -4,7 +4,7 @@
 #include <functional>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <unordered_map>
-
+#include <opencv2/calib3d.hpp>
 
 typedef std::function<geometry_msgs::msg::Transform(apriltag_detection_t* const, const std::array<double, 4>&, const double&)> pose_estimation_f;
 
@@ -12,5 +12,4 @@ extern const std::unordered_map<std::string, pose_estimation_f> pose_estimation_
 
 geometry_msgs::msg::Transform pnp_bundle(std::vector<apriltag_detection_t*> detections,
                                          const std::array<double, 4>& intr,
-                                         std::unordered_map<int, double> tagsizes,
-                                         std::unordered_map<int, std::vector<double>> transforms);
+                                         const std::unordered_map<int, std::array<cv::Point3d, 4>>& id_to_corners);

--- a/src/pose_estimation.hpp
+++ b/src/pose_estimation.hpp
@@ -9,3 +9,8 @@
 typedef std::function<geometry_msgs::msg::Transform(apriltag_detection_t* const, const std::array<double, 4>&, const double&)> pose_estimation_f;
 
 extern const std::unordered_map<std::string, pose_estimation_f> pose_estimation_methods;
+
+geometry_msgs::msg::Transform pnp_bundle(std::vector<apriltag_detection_t*> detections,
+                                         const std::array<double, 4>& intr,
+                                         std::unordered_map<int, double> tagsizes,
+                                         std::unordered_map<int, std::vector<double>> transforms);

--- a/src/pose_estimation.hpp
+++ b/src/pose_estimation.hpp
@@ -3,8 +3,8 @@
 #include <apriltag/apriltag.h>
 #include <functional>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <unordered_map>
 #include <opencv2/calib3d.hpp>
+#include <unordered_map>
 
 typedef std::function<geometry_msgs::msg::Transform(apriltag_detection_t* const, const std::array<double, 4>&, const double&)> pose_estimation_f;
 


### PR DESCRIPTION
Additional enhancements:
- Added check to enforce bundle tag transform length = 7
- Pre-computed bundle-frame corners per tag
- Tried to use const& references wherever possible

As far as testing, I've validated that the node works in place of the latest kilted deb release on a robot, that it compiles, and that tag bundle detection for a similar bundle setup to cfg/tags_36h11.yaml (with a 0+1 bundle, and a 0 bundle).

This should be reviewed and merged after #62.

I have been using this branch on several robots at my workplace for several weeks without issue at this point. Tag bundles make detection much more flexible :)
