### PR TITLE
add AlmaLinux 9 and 10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
           - {image: "ubuntu:22.04", ros: humble}
           - {image: "ubuntu:24.04", ros: jazzy}
           - {image: "ubuntu:26.04", ros: lyrical}
-          - {image: "almalinux:8", ros: humble}
+          - {image: "almalinux:8",  ros: humble}
+          - {image: "almalinux:9",  ros: jazzy}
+          - {image: "almalinux:10", ros: lyrical}
 
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
Needs:
- [ ] libyuv in EPEL: https://github.com/ros/rosdistro/issues/51089
- [ ] `camera_ros` release to RHEL