### PR TITLE
Scope GNU ld options to Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_STANDARD 14)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Werror -Wall -Wextra -Wpedantic)
-  add_link_options("-Wl,-z,relro,-z,now,-z,defs")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_link_options("-Wl,-z,relro,-z,now,-z,defs")
+  endif()
 endif()
 
 option(ASAN "use AddressSanitizer to detect memory issues" OFF)


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-apriltag-ros.osx.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: the -Wl,-z linker options are GNU/Linux linker hardening flags and are not accepted by the Apple linker. Keeping warning flags enabled while applying the -z options only on Linux preserves the existing policy where those flags are valid and allows non-Linux toolchains to configure.